### PR TITLE
Generate JWT secrets

### DIFF
--- a/config/env/production/server.js
+++ b/config/env/production/server.js
@@ -1,4 +1,9 @@
 module.exports = ({ env }) => ({
   host: "0.0.0.0",
   url: env("RENDER_EXTERNAL_URL"),
+  admin: {
+    auth: {
+      secret: env("ADMIN_JWT_SECRET"),
+    },
+  },
 });

--- a/render.yaml
+++ b/render.yaml
@@ -16,3 +16,7 @@ services:
         value: production
       - key: DATABASE_FILENAME
         value: /data/strapi.db
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ADMIN_JWT_SECRET
+        generateValue: true


### PR DESCRIPTION
Generate `JWT_SECRET` and `ADMIN_JWT_SECRET` on service creation, as recommended by @lauriejim in #1. These are 32 byte base64-encoded secrets, as described in Render's [YAML spec](https://render.com/docs/yaml-spec). 