### PR TITLE
Fix regression that dropped custom public/uploads path

### DIFF
--- a/config/env/production/server.js
+++ b/config/env/production/server.js
@@ -1,3 +1,6 @@
 module.exports = ({ env }) => ({
   url: env("RENDER_EXTERNAL_URL"),
+  dirs: {
+    public: "/data/public"
+  },
 });

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@strapi/plugin-i18n": "4.1.5",
-    "@strapi/strapi": "4.1.5",
-    "@strapi/plugin-users-permissions": "4.1.5",
+    "@strapi/plugin-i18n": "4.1.7",
+    "@strapi/strapi": "4.1.7",
+    "@strapi/plugin-users-permissions": "4.1.7",
     "sqlite3": "^5.0.2"
   },
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,10 +1549,10 @@
     escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
 
-"@strapi/admin@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-4.1.5.tgz#460551f01e625efd822b456fad235779b18e88a5"
-  integrity sha512-vT7FEvoKCyHE+QgMSoDoc6HV/cvAGjOsh7I+tTbKvhHpbp4tja/KLB1Pd4v6kWBSvOOEfFz0PuqMPchw69oRQw==
+"@strapi/admin@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-4.1.7.tgz#bdf9939e342522058a86a02f7469ac90ccc34fd5"
+  integrity sha512-HJxN3ZmaaxQAl/jjemkjVQFJE0B0fxwHBKunsGMnEBNEL9alIyWt8iBzOGdoc+80rMhY1VcmOEa3ABaM52Hr0g==
   dependencies:
     "@babel/core" "7.16.7"
     "@babel/plugin-proposal-async-generator-functions" "7.16.7"
@@ -1570,11 +1570,11 @@
     "@fortawesome/free-brands-svg-icons" "^5.15.3"
     "@fortawesome/free-solid-svg-icons" "^5.15.3"
     "@fortawesome/react-fontawesome" "^0.1.14"
-    "@strapi/babel-plugin-switch-ee-ce" "4.1.5"
+    "@strapi/babel-plugin-switch-ee-ce" "4.1.7"
     "@strapi/design-system" "0.0.1-alpha.79"
-    "@strapi/helper-plugin" "4.1.5"
+    "@strapi/helper-plugin" "4.1.7"
     "@strapi/icons" "0.0.1-alpha.79"
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
     axios "0.24.0"
     babel-loader "8.2.3"
     babel-plugin-styled-components "2.0.2"
@@ -1654,20 +1654,20 @@
     webpackbar "5.0.0-3"
     yup "^0.32.9"
 
-"@strapi/babel-plugin-switch-ee-ce@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/babel-plugin-switch-ee-ce/-/babel-plugin-switch-ee-ce-4.1.5.tgz#4c0004c3ac41b203e29e08ca256cf4bee596fd90"
-  integrity sha512-DEXubsaM3wSj8ByplbXpupsd06DmFEQVMncKi/EP/q7D0LjZEywsHJuGqjAGegMxr3fy6iDLnANatE/gz35Elg==
+"@strapi/babel-plugin-switch-ee-ce@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/babel-plugin-switch-ee-ce/-/babel-plugin-switch-ee-ce-4.1.7.tgz#8774711748517eddc63a65acd35be20b15f93de1"
+  integrity sha512-TQu21a34bDaBdxBcoTsL4V/iUGJKMSPE2A9G9UYIVFE6hgzJv9jcYflDI6rs0IH5nkoKbNbpAyJU5ND2kaLamw==
 
-"@strapi/database@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-4.1.5.tgz#22c5bd623b1bada992824f21710ffe738dc4df58"
-  integrity sha512-bxyDgpugHG/nj9BIi0536QW2ku2S8nG4+M3gOVtNNRp+KkXRgQvHENH8k5r+uHF/HOTw4HJ31iU8QnhThCxgBg==
+"@strapi/database@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-4.1.7.tgz#88011e560e3843c2d4c7727c6672565021ecd54d"
+  integrity sha512-bsSGbpjJZ8Sbj+9OEF5njjiqZ2RM4ZAl9BepApOUhBtln5oMokgdZX1wW02A03TJe0l/sfPIqWS0Za0h3CZp3w==
   dependencies:
     date-fns "2.22.1"
     debug "4.3.1"
     fs-extra "10.0.0"
-    knex "0.95.6"
+    knex "1.0.4"
     lodash "4.17.21"
     umzug "2.3.0"
 
@@ -1680,10 +1680,10 @@
     compute-scroll-into-view "^1.0.17"
     prop-types "^15.7.2"
 
-"@strapi/generate-new@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/generate-new/-/generate-new-4.1.5.tgz#18776c3b4d48042f953ad0f9bab22ea353db784e"
-  integrity sha512-i9jfFM3bzuIgXoVGI3yQ0RglVp0x/0ksPj7Mbd6aRmVqfjpDpcfrN/S701Ahi0TFCfPaDzdJ/TN4Ss/JAxeJVg==
+"@strapi/generate-new@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/generate-new/-/generate-new-4.1.7.tgz#559a8776ea1a24c39a9e6670f72a04bf687915fe"
+  integrity sha512-zl0veo1M/6HpUYrZmr1goqJ79lLYNcz+1kBdO2fK/ZNQYj+dEq6nIgb7k4Fg/2lxyK9WqkZmAvkGu67iGjMZZg==
   dependencies:
     "@sentry/node" "6.3.0"
     chalk "^4.1.1"
@@ -1697,23 +1697,23 @@
     tar "6.1.11"
     uuid "^3.3.2"
 
-"@strapi/generators@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-4.1.5.tgz#d219fe3ce5aa1df4f2b0751e1694b71114bf2427"
-  integrity sha512-3b1ekYkgP4tLYM03hqDptqFtd923cyTi6lY9oE7ATU1PEGIQ2ZM+LYh8moYoqwMirgHmUfbqMllNz486ulHSfA==
+"@strapi/generators@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-4.1.7.tgz#ba5a5084366714a57ef22c8f407e14690f8a6826"
+  integrity sha512-oVLX3iQx7DNa9i11MDdWPZ+Unq5c7kq5ZN2d6+uFB7bTE7ZWbWj7/JAUCorP9t54j8LgrmFAFDQrscfuE2Cu1A==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
     chalk "4.1.2"
     fs-extra "10.0.0"
     node-plop "0.26.3"
     plop "2.7.6"
     pluralize "8.0.0"
 
-"@strapi/helper-plugin@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/helper-plugin/-/helper-plugin-4.1.5.tgz#f6032b38af88a02d64552cbb48ca382bc48c5288"
-  integrity sha512-Pog53h0W+dgA+QjZpcrPgtt+hkBcRx9LYJ/CAW+BMCtqnqP0qcqQFtP5xPPxSJCkkmPX4GJT3XRWJUnjdPEq/A==
+"@strapi/helper-plugin@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/helper-plugin/-/helper-plugin-4.1.7.tgz#2d17072c9aee59770b1ac77dc23963484ca7788b"
+  integrity sha512-GQW1xH9wu1f6nDS3eLpmG+hC5dYjsXK/Zvbqn3cMLN5WQhDgjwIqziohDNaXdqJSyJ64a+6CofPNwb1upTEHZQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.2"
     "@fortawesome/fontawesome-svg-core" "^1.2.35"
@@ -1744,32 +1744,32 @@
   dependencies:
     rimraf "^3.0.2"
 
-"@strapi/logger@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-4.1.5.tgz#f80aeda35e57a321b16ea8edd3763e10fdcd3d85"
-  integrity sha512-pbzIKf6E8OBPBMPIfTl0s/yH4HF9EEqhMR5K3lPGwqONsECmmDgk4GfITVSdoPjy1DIMdERpFFBc4hLtrtCRXg==
+"@strapi/logger@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-4.1.7.tgz#9ad002dbbec916a32e1bb0754582d569d8f4a439"
+  integrity sha512-Wb1btxyRqQ5VZePzpatXS0qtue7wdNuCq5OB96LB65Uq4mtXI66g3tenq6lyCGHwNzMZRdlAHrzGssHYyK8wmA==
   dependencies:
     lodash "4.17.21"
     winston "3.3.3"
 
-"@strapi/plugin-content-manager@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-manager/-/plugin-content-manager-4.1.5.tgz#5dd122e66df4a859378528f5aea6aa8e2f548551"
-  integrity sha512-W6Y+uo2bAmky9YpShbBk+UjiIy5gOqaFwqAQpAEmHoeA7wLWbIZAlkqMdkTglHoJNz1O5VusXwAdpJUrOkVgpg==
+"@strapi/plugin-content-manager@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-manager/-/plugin-content-manager-4.1.7.tgz#b4acd1e8c330966d53d88fbc8f62cf509dbb8896"
+  integrity sha512-6Nxx3JNd6vIeLP25H0KIkh/Qwm8Vc5kBI7hqkD+p4SwK1XL7JEjHlgBDzkFY2uNGFUiEI6VKb6NPQnySHXDWzw==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
     lodash "4.17.21"
 
-"@strapi/plugin-content-type-builder@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.1.5.tgz#0f9689b038599328d4f62e31e4c7cf8ec7880968"
-  integrity sha512-iGexcsfZ/YyZAlsBBSpT0+Bb/ecSxPBDEfqkj0YkAz8KNZSfSL1D/mt9XhgNGyUhuvSm+L0UR4sztcay9GR3aA==
+"@strapi/plugin-content-type-builder@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.1.7.tgz#533fc706e4dd0952c0311046046344fe0c17ecd7"
+  integrity sha512-UMHei9ND66HrdFi7nkMdi7OecYB3DURMpmNr9UnakLTgY446y2VbAPstHKJlc3Rh7HojqEae+MhCwJXgfQ0DSw==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/generators" "4.1.5"
-    "@strapi/helper-plugin" "4.1.5"
-    "@strapi/utils" "4.1.5"
+    "@strapi/generators" "4.1.7"
+    "@strapi/helper-plugin" "4.1.7"
+    "@strapi/utils" "4.1.7"
     fs-extra "10.0.0"
     lodash "4.17.21"
     pluralize "^8.0.0"
@@ -1783,31 +1783,31 @@
     reselect "^4.0.0"
     yup "^0.32.9"
 
-"@strapi/plugin-email@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-email/-/plugin-email-4.1.5.tgz#d0f571b40c1c9ad91707ec9b3476431dfc10e085"
-  integrity sha512-aYV8/dNhaEzohBYE4dQeGATNDys6SUwVfYMcyXnqPfhckz/26gPTqMuKl8g2ZR2z3DFbujRrT7wZREr9Tg/L/A==
+"@strapi/plugin-email@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-email/-/plugin-email-4.1.7.tgz#f9945a91d9de12bc562686f969b0f3c103bd743c"
+  integrity sha512-vRp7LIFW922SjNgBzF2WrRW2YUaby+Iw++2/tWdmwWIjgcZm1tfqinF0QRHLV2Df/j5syHbMxe1y60poWXDzsg==
   dependencies:
-    "@strapi/provider-email-sendmail" "4.1.5"
-    "@strapi/utils" "4.1.5"
+    "@strapi/provider-email-sendmail" "4.1.7"
+    "@strapi/utils" "4.1.7"
     lodash "4.17.21"
 
-"@strapi/plugin-i18n@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-i18n/-/plugin-i18n-4.1.5.tgz#84e0f47b9847fb08a86a0bb50b00d7481c1d69c6"
-  integrity sha512-gQu0VoSxyGHVKooTbvMt6bxxQdVRFh6KaI29nh44yUenVKQsjSkpUwTUpSUrG9GZvnTr4RsDKPlg8DY+XIUumQ==
+"@strapi/plugin-i18n@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-i18n/-/plugin-i18n-4.1.7.tgz#6a04627e7d7455b442d19cf0d2df472a0b752b8c"
+  integrity sha512-vi/tP3zWQEVzx4J8NJgReOwuzCoCIvKECfGm09ps0ThYdeWn7v+WJGBmI6YAxhw7sXwG86apFgqh1aRrMpAuoQ==
   dependencies:
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
     lodash "4.17.21"
 
-"@strapi/plugin-upload@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-upload/-/plugin-upload-4.1.5.tgz#8f8ec6ba419941cddcf62bec2427f81498a60981"
-  integrity sha512-EBkbvmJJI+pfh25sDvofQDMxkAtTpql18zfEX5+YA1UePKIMNZ5EL65tKhhKqvCiROx4WVAQWWHib1GSoBCcvg==
+"@strapi/plugin-upload@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-upload/-/plugin-upload-4.1.7.tgz#6e5629a6527ab68442fdc378d69dae780f2125e7"
+  integrity sha512-XowbAknXYlO7GAA0V6zO9ZS/J0KpOiXnwBEflZ1+aapr7gRz3r6PY+oSwZLaF4GImG3tcm4meuCOkkMScAKzVw==
   dependencies:
-    "@strapi/helper-plugin" "4.1.5"
-    "@strapi/provider-upload-local" "4.1.5"
-    "@strapi/utils" "4.1.5"
+    "@strapi/helper-plugin" "4.1.7"
+    "@strapi/provider-upload-local" "4.1.7"
+    "@strapi/utils" "4.1.7"
     byte-size "7.0.1"
     cropperjs "1.5.11"
     fs-extra "10.0.0"
@@ -1824,14 +1824,14 @@
     react-router-dom "5.2.0"
     sharp "0.30.1"
 
-"@strapi/plugin-users-permissions@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.1.5.tgz#ae5e9781a0eeea54363832f685b7ebf8550b70f9"
-  integrity sha512-/bpZhNUCp8EeOiMUNde9RKwWfWCkFUPUBfGna7aJVzFEsHfYy0xJ7eNA5eUz70l13ZeJcbL+S4HSRjMH4m2Bmg==
+"@strapi/plugin-users-permissions@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.1.7.tgz#5698d812aee62361ca5c7335eb53a86f47e9e240"
+  integrity sha512-o0GfMvCu8xQYdf9giJc/9LPSQ7nhNkzASpGBcLrhblGHlm3cvDqEACv8m8PdsJxivbvNc53eHOCePr3DfqyeuA==
   dependencies:
     "@purest/providers" "^1.0.2"
-    "@strapi/helper-plugin" "4.1.5"
-    "@strapi/utils" "4.1.5"
+    "@strapi/helper-plugin" "4.1.7"
+    "@strapi/utils" "4.1.7"
     bcryptjs "2.4.3"
     grant-koa "5.4.8"
     jsonwebtoken "^8.1.0"
@@ -1849,38 +1849,39 @@
     url-join "4.0.1"
     uuid "^3.1.0"
 
-"@strapi/provider-email-sendmail@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.1.5.tgz#756d4044f849a2ccffa0c7fb3d642fff58726b5f"
-  integrity sha512-mbBfxr5V1vicpUzwy7EIP8NyOzUCE7lcF5mofXffaK0Bn9wx24Wv28hfO6nlI/YDrtj13j03SL3jcfN734AI/g==
+"@strapi/provider-email-sendmail@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.1.7.tgz#1a0924dc46941c7bd2883a3f5598818609e314bd"
+  integrity sha512-EBWCiYjftllE537ocHioOVoJyyHiiG/z2K1hVUhnvuiUIQBvMK0tCboqkWZMXcOmg73lASwxjtMERqzhs0G/Zw==
   dependencies:
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
     sendmail "^1.6.1"
 
-"@strapi/provider-upload-local@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-4.1.5.tgz#4f14659ed2a563e76ea6c02ddf94fa1db72c6cef"
-  integrity sha512-O71yVGG+3xsefwEeugweLhBMk91aHsGgukN7c4vHwl2dbHZSE7sZ8ndFuwvG29CYgNBJuW+K/DhdXotnk64Cjg==
+"@strapi/provider-upload-local@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-4.1.7.tgz#fda113395791c1bca5c20cf1ad277a00a2c2feca"
+  integrity sha512-N3N6+YhNWypbIFYXpeyW7bkTuVGZ5YKbxZ74gDWRwXW7PLnNmb30Fg94JVEB2F6SlJzEMdLStDIZuYyQ+lIjhA==
   dependencies:
-    "@strapi/utils" "4.1.5"
+    "@strapi/utils" "4.1.7"
+    fs-extra "10.0.0"
 
-"@strapi/strapi@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-4.1.5.tgz#ed3e17a93a93afe86833f29f69a5c5c406f0b494"
-  integrity sha512-+67qAaA1AM0I2C1/Y7rBpxHyqlN9g2eFvbt/6hYcbtb98D01Qm5JJV6/qj8+pb/8DJa2mxtQ2kNT65ob9EhtdQ==
+"@strapi/strapi@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-4.1.7.tgz#c3455ee7a0b7b6e4d16dab3dff1aa9ee197084b3"
+  integrity sha512-h73yo5z/wq7KPHbWcpvd52xXzYmo5OQqtp8wY3YQzOh0voy34XcHOD2apg9/AAx9LxkaSfo92OMMvkD5/QFo2w==
   dependencies:
     "@koa/cors" "3.1.0"
     "@koa/router" "10.1.1"
-    "@strapi/admin" "4.1.5"
-    "@strapi/database" "4.1.5"
-    "@strapi/generate-new" "4.1.5"
-    "@strapi/generators" "4.1.5"
-    "@strapi/logger" "4.1.5"
-    "@strapi/plugin-content-manager" "4.1.5"
-    "@strapi/plugin-content-type-builder" "4.1.5"
-    "@strapi/plugin-email" "4.1.5"
-    "@strapi/plugin-upload" "4.1.5"
-    "@strapi/utils" "4.1.5"
+    "@strapi/admin" "4.1.7"
+    "@strapi/database" "4.1.7"
+    "@strapi/generate-new" "4.1.7"
+    "@strapi/generators" "4.1.7"
+    "@strapi/logger" "4.1.7"
+    "@strapi/plugin-content-manager" "4.1.7"
+    "@strapi/plugin-content-type-builder" "4.1.7"
+    "@strapi/plugin-email" "4.1.7"
+    "@strapi/plugin-upload" "4.1.7"
+    "@strapi/utils" "4.1.7"
     bcryptjs "2.4.3"
     boxen "5.1.2"
     chalk "4.1.2"
@@ -1920,10 +1921,10 @@
     statuses "2.0.1"
     uuid "^3.3.2"
 
-"@strapi/utils@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.5.tgz#3e80f59476cab470ba0fdb42a075b5ae47e998f2"
-  integrity sha512-Oz7ur7TsoqA4IOPdk6H3YwsVZ+FOi9wp+iRReKao8yfo4YKJjSYlHQlNXUaAqOOlFnT0ol7G3KF+uF8jLcfxDA==
+"@strapi/utils@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.7.tgz#b4b898ef1fcb69b9c799b2458cd0397cd9cf6f48"
+  integrity sha512-Qxxh3+JaBC2MnYG/IZVMMqVGJO/TIGzKZdVJv4ZCC07hKUuZHnRgnEEGGqMIQHfXF5VJBqlKdkzkdDJldSBxRw==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
     date-fns "2.24.0"
@@ -3569,15 +3570,15 @@ color@^4.2.0:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colorette@1.2.1, colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
-
-colorette@^2.0.10, colorette@^2.0.14:
+colorette@2.0.16, colorette@^2.0.10, colorette@^2.0.14:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
 colors@1.4.0:
   version "1.4.0"
@@ -3609,7 +3610,7 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^7.0.0, commander@^7.1.0:
+commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -3998,19 +3999,19 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@4.3.3, debug@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.2:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5091,10 +5092,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getopts@2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.5.tgz#67a0fe471cacb9c687d817cab6450b96dde8313b"
-  integrity sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==
+getopts@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.3.0.tgz#71e5593284807e03e2427449d4f6712a268666f4"
+  integrity sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -6464,23 +6465,23 @@ klona@^2.0.3:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-knex@0.95.6:
-  version "0.95.6"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.6.tgz#5fc60ffc2935567bf122925526b1b06b8dbca785"
-  integrity sha512-noRcmkJl1MdicUbezrcr8OtVLcqQ/cfLIwgAx5EaxNxQOIJff88rBeyLywUScGhQNd/b78DIKKXZzLMrm6h/cw==
+knex@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-1.0.4.tgz#b9db3c60d0e3a4af37239bb879244e50eb748124"
+  integrity sha512-cMQ81fpkVmr4ia20BtyrD3oPere/ir/Q6IGLAgcREKOzRVhMsasQ4nx1VQuDRJjqq6oK5kfcxmvWoYkHKrnuMA==
   dependencies:
-    colorette "1.2.1"
-    commander "^7.1.0"
-    debug "4.3.1"
+    colorette "2.0.16"
+    commander "^8.3.0"
+    debug "4.3.3"
     escalade "^3.1.1"
     esm "^3.2.25"
-    getopts "2.2.5"
+    getopts "2.3.0"
     interpret "^2.2.0"
     lodash "^4.17.21"
-    pg-connection-string "2.4.0"
-    rechoir "^0.7.0"
+    pg-connection-string "2.5.0"
+    rechoir "^0.8.0"
     resolve-from "^5.0.0"
-    tarn "^3.0.1"
+    tarn "^3.0.2"
     tildify "2.0.0"
 
 koa-body@4.2.0:
@@ -8100,10 +8101,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pg-connection-string@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
-  integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
+pg-connection-string@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+  integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -8687,6 +8688,13 @@ rechoir@^0.7.0:
   dependencies:
     resolve "^1.9.0"
 
+rechoir@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz#49f866e0d32146142da3ad8f0eff352b3215ff22"
+  integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
+  dependencies:
+    resolve "^1.20.0"
+
 redis-commands@*, redis-commands@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.6.0.tgz#36d4ca42ae9ed29815cdb30ad9f97982eba1ce23"
@@ -9010,7 +9018,7 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.12.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resolve@^1.14.2, resolve@^1.9.0:
+resolve@^1.14.2, resolve@^1.20.0, resolve@^1.9.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -9991,7 +9999,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tarn@^3.0.1:
+tarn@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==


### PR DESCRIPTION
Strapi v4 lost the ability to override the public directory (I believe it was an unintended regression). v4.1.6 re-added that functionality but in a different way than how it worked in Strapi pre v4. This Strapi PR https://github.com/strapi/strapi/pull/12534 moves the configuration of the location of the public directory to config/server.js. We use this to override Strapi's default only in production so that the public folder contents can be saved on a persistent disk.

Although https://github.com/strapi/strapi/pull/12534 was merged on Mar 25, the change wasn't included in a release until 4.1.6, which was released on Mar 30.

Steps I took to test this change:
1. Deploy the branch as a Blueprint deploy
2. Using the Strapi Admin GUI, uploaded an piece of media (an image).
3. In the shell, verified that that image was in `/data/public/uploads` (within the persistent disk) and not within the `public` folder within the deployed source code.
4. In the Admin GUI, created a piece of data (a User record)
5. In the shell, verified that `sqlite.db` was in `/data` and not within the deployed source code.
6. Did a second deploy of the same service and verified that the above image file and `sqlite.db` weren't deleted and that their contents showed up in the Strapi Admin GUI

🎉 