### PR TITLE
Ingore the updater lock/config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ license.txt
 exports
 .cache
 build
+.strapi-updater.json


### PR DESCRIPTION
I noticed that this file is created on running, but it's an autogenerated artifact.

As such, my (personal) rule of thumb is to to ignore such files. I thought this might worth considering in this example?